### PR TITLE
Throw exception up on bad request response

### DIFF
--- a/lib/data/repository/repository_authentication_impl.dart
+++ b/lib/data/repository/repository_authentication_impl.dart
@@ -10,64 +10,77 @@ import 'package:strava_flutter/common/injections.dart';
 import 'package:uni_links/uni_links.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class RepositoryAuthenticationImpl extends RepositoryAuthentication{
-
+class RepositoryAuthenticationImpl extends RepositoryAuthentication {
   @override
-  Future<TokenResponse> authenticate({required List<AuthenticationScope> scopes, required String redirectUrl, bool forceShowingApproval = false}) async{
+  Future<TokenResponse> authenticate(
+      {required List<AuthenticationScope> scopes,
+      required String redirectUrl,
+      bool forceShowingApproval = false}) async {
     var completer = Completer<TokenResponse>();
     var token = await sl<SessionManager>().getToken();
     if (token == null) {
-      completer.complete(_completeAuthentication(scopes: scopes, forceShowingApproval: forceShowingApproval, redirectUrl: redirectUrl));
-    }else{
-      List<AuthenticationScope> oldScopes = AuthenticationScopeHelper.generateScopes(token.scopes ?? "");
+      completer.complete(_completeAuthentication(
+          scopes: scopes,
+          forceShowingApproval: forceShowingApproval,
+          redirectUrl: redirectUrl));
+    } else {
+      List<AuthenticationScope> oldScopes =
+          AuthenticationScopeHelper.generateScopes(token.scopes ?? "");
       var isScopesAreSame = _compareScopes(oldScopes, scopes);
-      if(isScopesAreSame){
-        if(sl<SessionManager>().isTokenExpired(token)){
-          _refreshAccessToken(
-              sl<SessionManager>().clientId,
-              sl<SessionManager>().secret,
-              token.refreshToken)
-              .then((refreshResult){
-             sl<SessionManager>().setToken(
-                scopes: scopes,
-                token: TokenResponse(
-                    tokenType: token.tokenType,
-                    expiresAt: refreshResult.expiresAt,
-                    expiresIn: refreshResult.expiresIn,
-                    refreshToken: refreshResult.refreshToken,
-                    accessToken: refreshResult.accessToken)
-            ).then((value) => completer.complete(refreshResult));
+      if (isScopesAreSame) {
+        if (sl<SessionManager>().isTokenExpired(token)) {
+          _refreshAccessToken(sl<SessionManager>().clientId,
+                  sl<SessionManager>().secret, token.refreshToken)
+              .then((refreshResult) {
+            sl<SessionManager>()
+                .setToken(
+                    scopes: scopes,
+                    token: TokenResponse(
+                        tokenType: token.tokenType,
+                        expiresAt: refreshResult.expiresAt,
+                        expiresIn: refreshResult.expiresIn,
+                        refreshToken: refreshResult.refreshToken,
+                        accessToken: refreshResult.accessToken))
+                .then((value) => completer.complete(refreshResult));
+          }).onError((error, stackTrace) {
+            completer.completeError(error!, stackTrace);
           });
-        }else{
+        } else {
           completer.complete(token);
         }
-      }else{
+      } else {
         ///Scopes have changed. we need a new token.
-        completer.complete(_completeAuthentication(scopes: scopes, forceShowingApproval: forceShowingApproval, redirectUrl: redirectUrl));
+        completer.complete(_completeAuthentication(
+            scopes: scopes,
+            forceShowingApproval: forceShowingApproval,
+            redirectUrl: redirectUrl));
       }
     }
     return completer.future;
   }
 
-  Future<TokenResponse> _completeAuthentication({
-    required List<AuthenticationScope> scopes,
-    required bool forceShowingApproval,
-    required String redirectUrl
-  }){
-    return _getStravaCode(redirectUrl: redirectUrl, scopes: scopes, forceShowingApproval: forceShowingApproval)
-        .then((code){
-      return _requestNewAccessToken(sl<SessionManager>().clientId, sl<SessionManager>().secret, code)
-          .then((token) async{
-         await sl<SessionManager>().setToken(token: token, scopes: scopes);
-         return token;
+  Future<TokenResponse> _completeAuthentication(
+      {required List<AuthenticationScope> scopes,
+      required bool forceShowingApproval,
+      required String redirectUrl}) {
+    return _getStravaCode(
+            redirectUrl: redirectUrl,
+            scopes: scopes,
+            forceShowingApproval: forceShowingApproval)
+        .then((code) {
+      return _requestNewAccessToken(
+              sl<SessionManager>().clientId, sl<SessionManager>().secret, code)
+          .then((token) async {
+        await sl<SessionManager>().setToken(token: token, scopes: scopes);
+        return token;
       });
     });
   }
 
   Future<String> _getStravaCode(
-      { required String redirectUrl,
-        required List<AuthenticationScope> scopes,
-        required bool forceShowingApproval}){
+      {required String redirectUrl,
+      required List<AuthenticationScope> scopes,
+      required bool forceShowingApproval}) {
     final Completer<String> completer = Completer<String>();
     final params =
         '?client_id=${sl<SessionManager>().clientId}&redirect_uri=$redirectUrl&response_type=code&approval_prompt=${forceShowingApproval ? "force" : "auto"}&scope=${AuthenticationScopeHelper.buildScopeString(scopes)}';
@@ -76,16 +89,14 @@ class RepositoryAuthenticationImpl extends RepositoryAuthentication{
     final reqAuth = authorizationEndpoint + params;
     print("Req URL: $reqAuth");
     launch(reqAuth,
-        forceWebView: false,
-        forceSafariVC: false,
-        enableJavaScript: true);
+        forceWebView: false, forceSafariVC: false, enableJavaScript: true);
     late final StreamSubscription linkStreamSubscription;
     linkStreamSubscription = uriLinkStream.listen((uri) {
       var error = uri?.queryParameters["error"];
       var code = uri?.queryParameters["code"];
-      if(error != null){
-        completer.completeError(Fault(errors: [],message: error));
-      }else{
+      if (error != null) {
+        completer.completeError(Fault(errors: [], message: error));
+      } else {
         completer.complete(code);
       }
       linkStreamSubscription.cancel();
@@ -93,33 +104,34 @@ class RepositoryAuthenticationImpl extends RepositoryAuthentication{
     return completer.future;
   }
 
-  Future<TokenResponse> _requestNewAccessToken(String clientID,
-      String secret,
-      String code){
+  Future<TokenResponse> _requestNewAccessToken(
+      String clientID, String secret, String code) {
     return ApiClient.postRequest(
         endPoint: "/v3/oauth/token",
         queryParameters: {
-          "client_id":clientID,
-          "client_secret":secret,
-          "code":code,
-          "grant_type":"authorization_code",
+          "client_id": clientID,
+          "client_secret": secret,
+          "code": code,
+          "grant_type": "authorization_code",
         },
-        dataConstructor: (data)=>TokenResponse.fromJson(data));
+        dataConstructor: (data) => TokenResponse.fromJson(data));
   }
 
-  Future<TokenResponse> _refreshAccessToken(String clientID,String secret, String refreshToken){
+  Future<TokenResponse> _refreshAccessToken(
+      String clientID, String secret, String refreshToken) {
     return ApiClient.postRequest<TokenResponse>(
         endPoint: "/v3/oauth/token",
         queryParameters: {
-          "client_id":clientID,
-          "client_secret":secret,
-          "grant_type":"refresh_token",
-          "refresh_token":refreshToken
+          "client_id": clientID,
+          "client_secret": secret,
+          "grant_type": "refresh_token",
+          "refresh_token": refreshToken
         },
-        dataConstructor: (data)=>TokenResponse.fromJson(data));
+        dataConstructor: (data) => TokenResponse.fromJson(data));
   }
 
-  bool _compareScopes(List<AuthenticationScope> left, List<AuthenticationScope> right){
+  bool _compareScopes(
+      List<AuthenticationScope> left, List<AuthenticationScope> right) {
     if (left.length != right.length) {
       return false;
     }
@@ -127,15 +139,15 @@ class RepositoryAuthenticationImpl extends RepositoryAuthentication{
   }
 
   @override
-  Future<void> deAuthorize() async{
-    var token = await  sl<SessionManager>().getToken();
+  Future<void> deAuthorize() async {
+    var token = await sl<SessionManager>().getToken();
 
-    var params = {"access_token":token?.accessToken ?? ""};
+    var params = {"access_token": token?.accessToken ?? ""};
     return ApiClient.postRequest(
-        baseUrl: "https://www.strava.com/",
-        endPoint: "/oauth/deauthorize",
-        queryParameters:params,
-        dataConstructor: (data)=>null)
-      .whenComplete(() => sl<SessionManager>().logout());
+            baseUrl: "https://www.strava.com/",
+            endPoint: "/oauth/deauthorize",
+            queryParameters: params,
+            dataConstructor: (data) => null)
+        .whenComplete(() => sl<SessionManager>().logout());
   }
 }


### PR DESCRIPTION
We noticed that sometimes Strava API returns 400 Bad Request because the refresh token has already been used. We need this exception to be thrown up, in order to handle it properly.