### PR TITLE
Rebuild example into an interactive API explorer

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,16 +1,46 @@
-# example
+# Strava Client Explorer (example app)
 
-A new Flutter project.
+An interactive playground for the `strava_client` package. Log in with OAuth,
+then run **every** repository call from a form and inspect the pretty-printed
+JSON response (or the Strava `Fault` on error).
 
-## Getting Started
+## What it covers
 
-This project is a starting point for a Flutter application.
+- OAuth login / de-authorization, with the access token shown and copyable.
+- A grouped list of API calls (Athlete, Activity, Club, Gear, Route, Running
+  races, Segment efforts, Segment, Stream, Upload).
+- A generated input form per call (ints, doubles, strings, dates, enums,
+  booleans, comma-separated key lists) so you can pass real parameters.
+- Read calls and a few write calls (`createActivity`, `updateActivity`,
+  `starSegment`) — write calls are tagged **WRITE** and mutate your data.
+- Pretty-printed JSON responses with a copy button.
 
-A few resources to get you started if this is your first Flutter project:
+## Setup
 
-- [Lab: Write your first Flutter app](https://flutter.dev/docs/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://flutter.dev/docs/cookbook)
+1. Create a Strava API application at <https://www.strava.com/settings/api>.
+   Set the **Authorization Callback Domain** to match the redirect used here
+   (`stravaflutter://redirect`).
+2. Copy the credentials template and fill it in:
 
-For help getting started with Flutter, view our
-[online documentation](https://flutter.dev/docs), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+   ```bash
+   cp lib/secret.dart.example lib/secret.dart
+   # edit lib/secret.dart -> clientId + secret
+   ```
+
+   `lib/secret.dart` is git-ignored.
+3. Run on a device or simulator:
+
+   ```bash
+   flutter pub get
+   flutter run
+   ```
+
+> Note: the app targets mobile (iOS/Android). OAuth uses native / in-app
+> browser flows via `flutter_web_auth_2`; the web target is not supported.
+
+## Adding a new call
+
+Calls are declared declaratively in
+[`lib/api/api_registry.dart`](lib/api/api_registry.dart) as `ApiCall` entries
+(group, name, params, and a `run` closure). The UI builds the form and result
+view automatically — no per-call widget code needed.

--- a/example/lib/api/api_models.dart
+++ b/example/lib/api/api_models.dart
@@ -1,0 +1,52 @@
+import 'package:strava_client/strava_client.dart';
+
+/// The kind of input an [ApiParam] collects.
+enum ParamType { int, double, string, bool, stringList, dateTime, enumValue }
+
+/// A single input for an [ApiCall].
+class ApiParam {
+  final String key;
+  final String label;
+  final ParamType type;
+  final String? hint;
+
+  /// Default value rendered into the field / used when left blank.
+  final dynamic defaultValue;
+
+  /// For [ParamType.enumValue]: the selectable values (usually `Enum.values`).
+  final List<Object>? enumValues;
+
+  /// For [ParamType.enumValue]: how to label each value in the dropdown.
+  final String Function(Object value)? enumLabel;
+
+  const ApiParam({
+    required this.key,
+    required this.label,
+    required this.type,
+    this.hint,
+    this.defaultValue,
+    this.enumValues,
+    this.enumLabel,
+  });
+}
+
+/// A runnable Strava API call, described declaratively so the UI can render a
+/// form for it and execute it generically.
+class ApiCall {
+  final String group;
+  final String name;
+  final String description;
+  final bool isWrite;
+  final List<ApiParam> params;
+  final Future<dynamic> Function(StravaClient client, Map<String, dynamic> args)
+      run;
+
+  const ApiCall({
+    required this.group,
+    required this.name,
+    required this.description,
+    required this.run,
+    this.params = const [],
+    this.isWrite = false,
+  });
+}

--- a/example/lib/api/api_registry.dart
+++ b/example/lib/api/api_registry.dart
@@ -1,0 +1,550 @@
+import 'package:strava_client/strava_client.dart';
+
+import 'api_models.dart';
+
+const _page = ApiParam(
+    key: "page", label: "Page", type: ParamType.int, defaultValue: 1);
+const _perPage = ApiParam(
+    key: "perPage", label: "Per page", type: ParamType.int, defaultValue: 30);
+
+ApiParam _id(String key, String label) =>
+    ApiParam(key: key, label: label, type: ParamType.int);
+
+final ApiParam _activityTypeParam = ApiParam(
+  key: "type",
+  label: "Activity type",
+  type: ParamType.enumValue,
+  defaultValue: ActivityTypeEnum.Ride,
+  enumValues: ActivityTypeEnum.values,
+  enumLabel: (v) => (v as ActivityTypeEnum).name,
+);
+
+/// Every Strava API call the example app can run, grouped by repository.
+final List<ApiCall> kApiCalls = [
+  // ---------------------------------------------------------------- Athlete
+  ApiCall(
+    group: "Athlete",
+    name: "getAuthenticatedAthlete",
+    description: "The currently authenticated athlete.",
+    run: (c, a) => c.athletes.getAuthenticatedAthlete(),
+  ),
+  ApiCall(
+    group: "Athlete",
+    name: "getAthleteZones",
+    description: "Heart-rate and power zones (correct /athlete/zones model).",
+    run: (c, a) => c.athletes.getAthleteZones(),
+  ),
+  ApiCall(
+    group: "Athlete",
+    name: "getAthleteStats",
+    description: "Activity totals/stats for an athlete id.",
+    params: [_id("athleteId", "Athlete id")],
+    run: (c, a) => c.athletes.getAthleteStats(a["athleteId"] as int),
+  ),
+
+  // --------------------------------------------------------------- Activity
+  ApiCall(
+    group: "Activity",
+    name: "getActivity",
+    description: "A detailed activity by id.",
+    params: [_id("activityId", "Activity id")],
+    run: (c, a) => c.activities.getActivity(a["activityId"] as int),
+  ),
+  ApiCall(
+    group: "Activity",
+    name: "listLoggedInAthleteActivities",
+    description: "Your activities within a date window.",
+    params: [
+      ApiParam(
+          key: "before",
+          label: "Before (ISO date)",
+          type: ParamType.dateTime,
+          defaultValue: DateTime.now()),
+      ApiParam(
+          key: "after",
+          label: "After (ISO date)",
+          type: ParamType.dateTime,
+          defaultValue: DateTime.now().subtract(const Duration(days: 30))),
+      _page,
+      _perPage,
+    ],
+    run: (c, a) => c.activities.listLoggedInAthleteActivities(
+        a["before"] as DateTime,
+        a["after"] as DateTime,
+        a["page"] as int,
+        a["perPage"] as int),
+  ),
+  ApiCall(
+    group: "Activity",
+    name: "listActivityComments",
+    description: "Comments on an activity.",
+    params: [_id("activityId", "Activity id")],
+    run: (c, a) => c.activities.listActivityComments(a["activityId"] as int),
+  ),
+  ApiCall(
+    group: "Activity",
+    name: "listActivityKudoers",
+    description: "Athletes who kudoed an activity.",
+    params: [_id("activityId", "Activity id")],
+    run: (c, a) => c.activities.listActivityKudoers(a["activityId"] as int),
+  ),
+  ApiCall(
+    group: "Activity",
+    name: "getLapsByActivityId",
+    description: "Laps of an activity.",
+    params: [_id("activityId", "Activity id")],
+    run: (c, a) => c.activities.getLapsByActivityId(a["activityId"] as int),
+  ),
+  ApiCall(
+    group: "Activity",
+    name: "getActivityZones",
+    description: "Zones for an activity.",
+    params: [_id("activityId", "Activity id")],
+    run: (c, a) => c.activities.getActivityZones(a["activityId"] as int),
+  ),
+  ApiCall(
+    group: "Activity",
+    name: "createActivity",
+    description: "Create a manual activity.",
+    isWrite: true,
+    params: [
+      ApiParam(key: "name", label: "Name", type: ParamType.string),
+      _activityTypeParam,
+      ApiParam(
+          key: "startDateLocal",
+          label: "Start date local (ISO)",
+          type: ParamType.dateTime,
+          defaultValue: DateTime.now()),
+      ApiParam(
+          key: "elapsedTime",
+          label: "Elapsed time (s)",
+          type: ParamType.int,
+          defaultValue: 3600),
+      ApiParam(
+          key: "description",
+          label: "Description",
+          type: ParamType.string,
+          defaultValue: ""),
+      ApiParam(
+          key: "distance",
+          label: "Distance (m)",
+          type: ParamType.double,
+          defaultValue: 0.0),
+      ApiParam(
+          key: "trainer",
+          label: "Trainer",
+          type: ParamType.bool,
+          defaultValue: false),
+      ApiParam(
+          key: "commute",
+          label: "Commute",
+          type: ParamType.bool,
+          defaultValue: false),
+    ],
+    run: (c, a) => c.activities.createActivity(CreateActivityRequest(
+        a["name"] as String,
+        a["type"] as ActivityTypeEnum,
+        a["startDateLocal"] as DateTime,
+        a["elapsedTime"] as int,
+        a["description"] as String,
+        a["distance"] as double,
+        a["trainer"] as bool,
+        a["commute"] as bool)),
+  ),
+  ApiCall(
+    group: "Activity",
+    name: "updateActivity",
+    description: "Update an existing activity.",
+    isWrite: true,
+    params: [
+      _id("activityId", "Activity id"),
+      ApiParam(key: "name", label: "Name (blank = skip)", type: ParamType.string),
+      ApiParam(
+          key: "description",
+          label: "Description (blank = skip)",
+          type: ParamType.string),
+      ApiParam(
+          key: "gearId", label: "Gear id (blank = skip)", type: ParamType.string),
+    ],
+    run: (c, a) => c.activities.updateActivity(
+          a["activityId"] as int,
+          UpdateActivityRequest(
+            name: (a["name"] as String?)?.isEmpty ?? true
+                ? null
+                : a["name"] as String,
+            description: (a["description"] as String?)?.isEmpty ?? true
+                ? null
+                : a["description"] as String,
+            gearId: (a["gearId"] as String?)?.isEmpty ?? true
+                ? null
+                : a["gearId"] as String,
+          ),
+        ),
+  ),
+
+  // ------------------------------------------------------------------- Club
+  ApiCall(
+    group: "Club",
+    name: "getClub",
+    description: "A club by id.",
+    params: [_id("clubId", "Club id")],
+    run: (c, a) => c.clubs.getClub(a["clubId"] as int),
+  ),
+  ApiCall(
+    group: "Club",
+    name: "getLoggedInAthleteClubs",
+    description: "Clubs you belong to.",
+    params: [_page, _perPage],
+    run: (c, a) =>
+        c.clubs.getLoggedInAthleteClubs(a["page"] as int, a["perPage"] as int),
+  ),
+  ApiCall(
+    group: "Club",
+    name: "listClubActivities",
+    description: "Recent activities of a club.",
+    params: [_id("clubId", "Club id"), _page, _perPage],
+    run: (c, a) => c.clubs.listClubActivities(
+        a["clubId"] as int, a["page"] as int, a["perPage"] as int),
+  ),
+  ApiCall(
+    group: "Club",
+    name: "listClubAdministrators",
+    description: "Administrators of a club.",
+    params: [_id("clubId", "Club id"), _page, _perPage],
+    run: (c, a) => c.clubs.listClubAdministrators(
+        a["clubId"] as int, a["page"] as int, a["perPage"] as int),
+  ),
+  ApiCall(
+    group: "Club",
+    name: "listClubMembers",
+    description: "Members of a club.",
+    params: [_id("clubId", "Club id"), _page, _perPage],
+    run: (c, a) => c.clubs.listClubMembers(
+        a["clubId"] as int, a["page"] as int, a["perPage"] as int),
+  ),
+
+  // ------------------------------------------------------------------- Gear
+  ApiCall(
+    group: "Gear",
+    name: "getGear",
+    description: "Gear (bike/shoe) by id.",
+    params: [_id("gearId", "Gear id")],
+    run: (c, a) => c.gears.getGear(a["gearId"] as int),
+  ),
+
+  // ------------------------------------------------------------------ Route
+  ApiCall(
+    group: "Route",
+    name: "getRoute",
+    description: "A route by id.",
+    params: [_id("routeId", "Route id")],
+    run: (c, a) => c.routes.getRoute(a["routeId"] as int),
+  ),
+  ApiCall(
+    group: "Route",
+    name: "listAthleteRoutes",
+    description: "Routes created by an athlete.",
+    params: [_id("athleteId", "Athlete id"), _page, _perPage],
+    run: (c, a) => c.routes.listAthleteRoutes(
+        a["athleteId"] as int, a["page"] as int, a["perPage"] as int),
+  ),
+  ApiCall(
+    group: "Route",
+    name: "exportRouteGPX",
+    description: "Export a route as GPX (binary).",
+    params: [_id("routeId", "Route id")],
+    run: (c, a) => c.routes.exportRouteGPX(a["routeId"] as int),
+  ),
+  ApiCall(
+    group: "Route",
+    name: "exportRouteTCX",
+    description: "Export a route as TCX (binary).",
+    params: [_id("routeId", "Route id")],
+    run: (c, a) => c.routes.exportRouteTCX(a["routeId"] as int),
+  ),
+
+  // ----------------------------------------------------------- RunningRaces
+  ApiCall(
+    group: "Running races",
+    name: "getRage",
+    description: "A running race by id.",
+    params: [_id("raceId", "Race id")],
+    run: (c, a) => c.runningRaces.getRage(a["raceId"] as int),
+  ),
+  ApiCall(
+    group: "Running races",
+    name: "listRunningRaces",
+    description: "Running races in a given year.",
+    params: [
+      ApiParam(
+          key: "year",
+          label: "Year",
+          type: ParamType.int,
+          defaultValue: DateTime.now().year)
+    ],
+    run: (c, a) => c.runningRaces.listRunningRaces(a["year"] as int),
+  ),
+
+  // --------------------------------------------------------- Segment effort
+  ApiCall(
+    group: "Segment efforts",
+    name: "getSegmentEffort",
+    description: "A segment effort by id.",
+    params: [_id("effortId", "Segment effort id")],
+    run: (c, a) => c.segmentEfforts.getSegmentEffort(a["effortId"] as int),
+  ),
+  ApiCall(
+    group: "Segment efforts",
+    name: "listSegmentEfforts",
+    description: "Your efforts on a segment within a date window.",
+    params: [
+      _id("segmentId", "Segment id"),
+      ApiParam(
+          key: "startDate",
+          label: "Start date (ISO)",
+          type: ParamType.dateTime,
+          defaultValue: DateTime.now().subtract(const Duration(days: 365))),
+      ApiParam(
+          key: "endDate",
+          label: "End date (ISO)",
+          type: ParamType.dateTime,
+          defaultValue: DateTime.now()),
+      _perPage,
+    ],
+    run: (c, a) => c.segmentEfforts.listSegmentEfforts(
+        a["segmentId"] as int,
+        a["startDate"] as DateTime,
+        a["endDate"] as DateTime,
+        a["perPage"] as int),
+  ),
+
+  // ---------------------------------------------------------------- Segment
+  ApiCall(
+    group: "Segment",
+    name: "getSegment",
+    description: "A detailed segment by id.",
+    params: [_id("segmentId", "Segment id")],
+    run: (c, a) => c.segments.getSegment(a["segmentId"] as int),
+  ),
+  ApiCall(
+    group: "Segment",
+    name: "listStarredSegments",
+    description: "Your starred segments.",
+    params: [_page, _perPage],
+    run: (c, a) =>
+        c.segments.listStarredSegments(a["page"] as int, a["perPage"] as int),
+  ),
+  ApiCall(
+    group: "Segment",
+    name: "starSegment",
+    description: "Star or unstar a segment.",
+    isWrite: true,
+    params: [
+      _id("segmentId", "Segment id"),
+      ApiParam(
+          key: "starred",
+          label: "Starred",
+          type: ParamType.bool,
+          defaultValue: true),
+    ],
+    run: (c, a) =>
+        c.segments.starSegment(a["segmentId"] as int, a["starred"] as bool),
+  ),
+  ApiCall(
+    group: "Segment",
+    name: "exploreSegments",
+    description: "Explore segments within a bounding box.",
+    params: [
+      ApiParam(
+          key: "swLat",
+          label: "SW latitude",
+          type: ParamType.double,
+          defaultValue: 37.821),
+      ApiParam(
+          key: "swLon",
+          label: "SW longitude",
+          type: ParamType.double,
+          defaultValue: -122.505),
+      ApiParam(
+          key: "neLat",
+          label: "NE latitude",
+          type: ParamType.double,
+          defaultValue: 37.842),
+      ApiParam(
+          key: "neLon",
+          label: "NE longitude",
+          type: ParamType.double,
+          defaultValue: -122.465),
+      _activityTypeParam,
+      ApiParam(
+          key: "minCat",
+          label: "Min climb category",
+          type: ParamType.int,
+          defaultValue: 0),
+      ApiParam(
+          key: "maxCat",
+          label: "Max climb category",
+          type: ParamType.int,
+          defaultValue: 5),
+    ],
+    run: (c, a) => c.segments.exploreSegments(
+        GeoPoint(a["swLat"] as double, a["swLon"] as double),
+        GeoPoint(a["neLat"] as double, a["neLon"] as double),
+        a["type"] as ActivityTypeEnum,
+        a["minCat"] as int,
+        a["maxCat"] as int),
+  ),
+  ApiCall(
+    group: "Segment",
+    name: "getLeaderBoard",
+    description: "Segment leaderboard.",
+    params: [
+      _id("segmentId", "Segment id"),
+      ApiParam(
+          key: "gender",
+          label: "Gender",
+          type: ParamType.enumValue,
+          defaultValue: SegmentGender.male,
+          enumValues: SegmentGender.values,
+          enumLabel: (v) => (v as SegmentGender).name),
+      ApiParam(
+          key: "ageGroup",
+          label: "Age group",
+          type: ParamType.enumValue,
+          defaultValue: SegmentAgeGroup.values.first,
+          enumValues: SegmentAgeGroup.values,
+          enumLabel: (v) => (v as SegmentAgeGroup).name),
+      ApiParam(
+          key: "weightClass",
+          label: "Weight class",
+          type: ParamType.enumValue,
+          defaultValue: SegmentWeightClass.values.first,
+          enumValues: SegmentWeightClass.values,
+          enumLabel: (v) => (v as SegmentWeightClass).name),
+      ApiParam(
+          key: "dateRange",
+          label: "Date range",
+          type: ParamType.enumValue,
+          defaultValue: SegmentDateRange.this_year,
+          enumValues: SegmentDateRange.values,
+          enumLabel: (v) => (v as SegmentDateRange).name),
+      ApiParam(
+          key: "clubId", label: "Club id (0 = none)", type: ParamType.int,
+          defaultValue: 0),
+      ApiParam(
+          key: "maxEntries",
+          label: "Max entries",
+          type: ParamType.int,
+          defaultValue: 10),
+      ApiParam(
+          key: "following",
+          label: "Following only",
+          type: ParamType.bool,
+          defaultValue: false),
+      _page,
+      _perPage,
+    ],
+    run: (c, a) => c.segments.getLeaderBoard(SegmentLeaderboardRequest(
+        a["dateRange"] as SegmentDateRange,
+        a["gender"] as SegmentGender,
+        a["ageGroup"] as SegmentAgeGroup,
+        a["weightClass"] as SegmentWeightClass,
+        a["segmentId"] as int,
+        a["clubId"] as int,
+        a["maxEntries"] as int,
+        a["following"] as bool,
+        a["page"] as int,
+        a["perPage"] as int)),
+  ),
+
+  // ----------------------------------------------------------------- Stream
+  ApiCall(
+    group: "Stream",
+    name: "getActivityStreams",
+    description: "Activity streams as a list (array form).",
+    params: [_id("activityId", "Activity id"), _streamKeys],
+    run: (c, a) => c.streams
+        .getActivityStreams(a["activityId"] as int, a["keys"] as List<String>),
+  ),
+  ApiCall(
+    group: "Stream",
+    name: "getActivityStreamsByType",
+    description: "Activity streams keyed by type (StreamCollection).",
+    params: [_id("activityId", "Activity id"), _streamKeys],
+    run: (c, a) => c.streams.getActivityStreamsByType(
+        a["activityId"] as int, a["keys"] as List<String>),
+  ),
+  ApiCall(
+    group: "Stream",
+    name: "getRouteStreams",
+    description: "Route streams as a list.",
+    params: [_id("routeId", "Route id")],
+    run: (c, a) => c.streams.getRouteStreams(a["routeId"] as int),
+  ),
+  ApiCall(
+    group: "Stream",
+    name: "getRouteStreamsByType",
+    description: "Route streams keyed by type.",
+    params: [_id("routeId", "Route id")],
+    run: (c, a) => c.streams.getRouteStreamsByType(a["routeId"] as int),
+  ),
+  ApiCall(
+    group: "Stream",
+    name: "getSegmentEffortStreams",
+    description: "Segment-effort streams as a list.",
+    params: [_id("effortId", "Segment effort id"), _streamKeys],
+    run: (c, a) => c.streams.getSegmentEffortStreams(
+        a["effortId"] as int, a["keys"] as List<String>),
+  ),
+  ApiCall(
+    group: "Stream",
+    name: "getSegmentEffortStreamsByType",
+    description: "Segment-effort streams keyed by type.",
+    params: [_id("effortId", "Segment effort id"), _streamKeys],
+    run: (c, a) => c.streams.getSegmentEffortStreamsByType(
+        a["effortId"] as int, a["keys"] as List<String>),
+  ),
+  ApiCall(
+    group: "Stream",
+    name: "getSegmentStreams",
+    description: "Segment streams as a list.",
+    params: [_id("segmentId", "Segment id"), _streamKeys],
+    run: (c, a) => c.streams
+        .getSegmentStreams(a["segmentId"] as int, a["keys"] as List<String>),
+  ),
+  ApiCall(
+    group: "Stream",
+    name: "getSegmentStreamsByType",
+    description: "Segment streams keyed by type.",
+    params: [_id("segmentId", "Segment id"), _streamKeys],
+    run: (c, a) => c.streams.getSegmentStreamsByType(
+        a["segmentId"] as int, a["keys"] as List<String>),
+  ),
+
+  // ----------------------------------------------------------------- Upload
+  ApiCall(
+    group: "Upload",
+    name: "getUpload",
+    description: "Status of an upload by id.",
+    params: [_id("uploadId", "Upload id")],
+    run: (c, a) => c.uploads.getUpload(a["uploadId"] as int),
+  ),
+];
+
+const _streamKeys = ApiParam(
+  key: "keys",
+  label: "Keys (comma separated)",
+  type: ParamType.stringList,
+  defaultValue: "distance,heartrate,watts",
+  hint: "time, distance, latlng, altitude, velocity_smooth, heartrate, "
+      "cadence, watts, temp, moving, grade_smooth",
+);
+
+/// Calls grouped by [ApiCall.group], preserving registry order.
+Map<String, List<ApiCall>> groupedApiCalls() {
+  final map = <String, List<ApiCall>>{};
+  for (final call in kApiCalls) {
+    map.putIfAbsent(call.group, () => []).add(call);
+  }
+  return map;
+}

--- a/example/lib/api/result_format.dart
+++ b/example/lib/api/result_format.dart
@@ -1,0 +1,25 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+/// Pretty-prints any Strava API result (model, list of models, binary, or
+/// primitive) as indented JSON.
+String formatResult(dynamic result) {
+  return const JsonEncoder.withIndent('  ').convert(_toEncodable(result));
+}
+
+dynamic _toEncodable(dynamic value) {
+  if (value == null) return null;
+  if (value is Uint8List) return '<binary: ${value.length} bytes>';
+  if (value is num || value is String || value is bool) return value;
+  if (value is List) return value.map(_toEncodable).toList();
+  if (value is Map) {
+    return value
+        .map((k, v) => MapEntry(k.toString(), _toEncodable(v)));
+  }
+  try {
+    // Strava models expose toJson(); explicit_to_json makes it fully expanded.
+    return (value as dynamic).toJson();
+  } catch (_) {
+    return value.toString();
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,35 +3,40 @@ import 'dart:async';
 import 'package:example/examples/authentication.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:intl/intl.dart';
 import 'package:strava_client/strava_client.dart';
 
+import 'api/api_models.dart';
+import 'api/api_registry.dart';
+import 'screens/call_screen.dart';
 import 'secret.dart';
 
-void main() => runApp(MyApp());
+void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
-  // This widget is the root of your application.
+  const MyApp({super.key});
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Strava Flutter',
+      title: 'Strava Client Explorer',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorSchemeSeed: const Color(0xFFFC4C02), // Strava orange
+        useMaterial3: true,
       ),
-      home: StravaFlutterPage(),
+      home: const StravaExplorerPage(),
     );
   }
 }
 
-class StravaFlutterPage extends StatefulWidget {
+class StravaExplorerPage extends StatefulWidget {
+  const StravaExplorerPage({super.key});
+
   @override
-  _StravaFlutterPageState createState() => _StravaFlutterPageState();
+  State<StravaExplorerPage> createState() => _StravaExplorerPageState();
 }
 
-class _StravaFlutterPageState extends State<StravaFlutterPage> {
-  final TextEditingController _textEditingController = TextEditingController();
-  final DateFormat dateFormatter = DateFormat("HH:mm:ss");
+class _StravaExplorerPageState extends State<StravaExplorerPage> {
+  final TextEditingController _tokenController = TextEditingController();
   late final StravaClient stravaClient;
 
   bool isLoggedIn = false;
@@ -39,170 +44,173 @@ class _StravaFlutterPageState extends State<StravaFlutterPage> {
 
   @override
   void initState() {
-    stravaClient = StravaClient(secret: secret, clientId: clientId);
     super.initState();
+    stravaClient = StravaClient(secret: secret, clientId: clientId);
   }
 
-  FutureOr<Null> showErrorMessage(dynamic error, dynamic stackTrace) {
-    if (error is Fault) {
-      showDialog(
-          context: context,
-          builder: (context) {
-            return AlertDialog(
-              title: Text("Did Receive Fault"),
-              content: Text(
-                  "Message: ${error.message}\n-----------------\nErrors:\n${(error.errors ?? []).map((e) => "Code: ${e.code}\nResource: ${e.resource}\nField: ${e.field}\n").toList().join("\n----------\n")}"),
-            );
-          });
-    }
+  @override
+  void dispose() {
+    _tokenController.dispose();
+    super.dispose();
   }
 
-  void testAuthentication() {
+  FutureOr<Null> _showError(dynamic error, dynamic stackTrace) {
+    final message = error is Fault
+        ? 'Fault: ${error.message}\n'
+            '${(error.errors ?? []).map((e) => "• ${e.code} (${e.field})").join("\n")}'
+        : error.toString();
+    if (!mounted) return null;
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Request failed'),
+        content: SingleChildScrollView(child: Text(message)),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('OK'))
+        ],
+      ),
+    );
+    return null;
+  }
+
+  void _login() {
     ExampleAuthentication(stravaClient).testAuthentication(
-      [
+      const [
         AuthenticationScope.profile_read_all,
         AuthenticationScope.read_all,
-        AuthenticationScope.activity_read_all
+        AuthenticationScope.activity_read_all,
+        AuthenticationScope.activity_write,
+        AuthenticationScope.profile_write,
       ],
       "stravaflutter://redirect",
     ).then((token) {
       setState(() {
         isLoggedIn = true;
         this.token = token;
+        _tokenController.text = token.accessToken;
       });
-      _textEditingController.text = token.accessToken;
-    }).catchError(showErrorMessage);
+    }).catchError(_showError);
   }
 
-  void testDeauth() {
-    ExampleAuthentication(stravaClient).testDeauthorize().then((value) {
+  void _logout() {
+    ExampleAuthentication(stravaClient).testDeauthorize().then((_) {
       setState(() {
         isLoggedIn = false;
-        this.token = null;
-        _textEditingController.clear();
+        token = null;
+        _tokenController.clear();
       });
-    }).catchError(showErrorMessage);
+    }).catchError(_showError);
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text("Flutter Strava Plugin"),
+        title: const Text('Strava Client Explorer'),
         actions: [
-          Icon(
-            isLoggedIn
-                ? Icons.radio_button_checked_outlined
-                : Icons.radio_button_off,
-            color: isLoggedIn ? Colors.white : Colors.red,
+          Padding(
+            padding: const EdgeInsets.only(right: 12),
+            child: Icon(
+              isLoggedIn ? Icons.cloud_done : Icons.cloud_off,
+              color: isLoggedIn ? Colors.green : Colors.red.shade300,
+            ),
           ),
-          SizedBox(
-            width: 8,
-          )
         ],
       ),
-      body: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [_login(), _apiGroups()],
-        ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _loginPanel(),
+          const Divider(height: 1),
+          Expanded(child: _callList()),
+        ],
       ),
     );
   }
 
-  Widget _login() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            ElevatedButton(
-              child: Text("Login With Strava"),
-              onPressed: testAuthentication,
-            ),
-            ElevatedButton(
-              child: Text("De Authorize"),
-              onPressed: testDeauth,
-            )
-          ],
-        ),
-        SizedBox(
-          height: 8,
-        ),
-        TextField(
-          minLines: 1,
-          maxLines: 3,
-          controller: _textEditingController,
-          decoration: InputDecoration(
-              border: OutlineInputBorder(),
-              label: Text("Access Token"),
-              suffixIcon: TextButton(
-                child: Text("Copy"),
+  Widget _loginPanel() {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              FilledButton.icon(
+                onPressed: _login,
+                icon: const Icon(Icons.login),
+                label: const Text('Login with Strava'),
+              ),
+              const SizedBox(width: 12),
+              OutlinedButton.icon(
+                onPressed: isLoggedIn ? _logout : null,
+                icon: const Icon(Icons.logout),
+                label: const Text('De-authorize'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _tokenController,
+            readOnly: true,
+            minLines: 1,
+            maxLines: 2,
+            decoration: InputDecoration(
+              border: const OutlineInputBorder(),
+              labelText: 'Access token',
+              isDense: true,
+              suffixIcon: IconButton(
+                icon: const Icon(Icons.copy),
                 onPressed: () {
                   Clipboard.setData(
-                          ClipboardData(text: _textEditingController.text))
-                      .then((value) =>
-                          ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                            content: Text("Copied!"),
-                          )));
+                      ClipboardData(text: _tokenController.text));
+                  ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Copied')));
                 },
-              )),
-        ),
-        Divider()
-      ],
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 
-  Widget _apiGroups() {
-    return IgnorePointer(
-      ignoring: !isLoggedIn,
-      child: AnimatedOpacity(
-        opacity: isLoggedIn ? 1.0 : 0.4,
-        duration: Duration(milliseconds: 200),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ListTile(
-              title: Text("Athletes"),
-              trailing: Icon(Icons.chevron_right),
-            ),
-            ListTile(
-              title: Text("Clubs"),
-              trailing: Icon(Icons.chevron_right),
-            ),
-            ListTile(
-              title: Text("Gears"),
-              trailing: Icon(Icons.chevron_right),
-            ),
-            ListTile(
-              title: Text("Routes"),
-              trailing: Icon(Icons.chevron_right),
-            ),
-            ListTile(
-              title: Text("Running Races"),
-              trailing: Icon(Icons.chevron_right),
-            ),
-            ListTile(
-              title: Text("Segment Efforts"),
-              trailing: Icon(Icons.chevron_right),
-            ),
-            ListTile(
-              title: Text("Segments"),
-              trailing: Icon(Icons.chevron_right),
-            ),
-            ListTile(
-              title: Text("Streams"),
-              trailing: Icon(Icons.chevron_right),
-            ),
-            ListTile(
-              title: Text("Uploads"),
-              trailing: Icon(Icons.chevron_right),
-            )
-          ],
+  Widget _callList() {
+    if (!isLoggedIn) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text('Login to run API calls.',
+              textAlign: TextAlign.center),
         ),
-      ),
+      );
+    }
+    final grouped = groupedApiCalls();
+    return ListView(
+      children: grouped.entries.map((entry) {
+        return ExpansionTile(
+          title: Text(entry.key,
+              style: const TextStyle(fontWeight: FontWeight.w600)),
+          children: entry.value.map(_callTile).toList(),
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _callTile(ApiCall call) {
+    return ListTile(
+      dense: true,
+      title: Text(call.name),
+      subtitle: Text(call.description),
+      leading: call.isWrite
+          ? const Icon(Icons.edit, color: Colors.orange, size: 20)
+          : const Icon(Icons.download, color: Colors.blueGrey, size: 20),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () => Navigator.of(context).push(MaterialPageRoute(
+        builder: (_) => CallScreen(client: stravaClient, call: call),
+      )),
     );
   }
 }

--- a/example/lib/screens/call_screen.dart
+++ b/example/lib/screens/call_screen.dart
@@ -1,0 +1,267 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:strava_client/strava_client.dart';
+
+import '../api/api_models.dart';
+import '../api/result_format.dart';
+
+/// A dynamic form + runner for a single [ApiCall].
+class CallScreen extends StatefulWidget {
+  final StravaClient client;
+  final ApiCall call;
+
+  const CallScreen({super.key, required this.client, required this.call});
+
+  @override
+  State<CallScreen> createState() => _CallScreenState();
+}
+
+class _CallScreenState extends State<CallScreen> {
+  final Map<String, TextEditingController> _controllers = {};
+  final Map<String, Object> _enumValues = {};
+  final Map<String, bool> _boolValues = {};
+
+  bool _loading = false;
+  String? _result;
+  bool _isError = false;
+
+  @override
+  void initState() {
+    super.initState();
+    for (final p in widget.call.params) {
+      switch (p.type) {
+        case ParamType.bool:
+          _boolValues[p.key] = (p.defaultValue as bool?) ?? false;
+          break;
+        case ParamType.enumValue:
+          _enumValues[p.key] =
+              (p.defaultValue as Object?) ?? p.enumValues!.first;
+          break;
+        default:
+          _controllers[p.key] =
+              TextEditingController(text: _initialText(p));
+      }
+    }
+  }
+
+  String _initialText(ApiParam p) {
+    final d = p.defaultValue;
+    if (d == null) return '';
+    if (d is DateTime) return d.toIso8601String();
+    return d.toString();
+  }
+
+  @override
+  void dispose() {
+    for (final c in _controllers.values) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  Map<String, dynamic> _collectArgs() {
+    final args = <String, dynamic>{};
+    for (final p in widget.call.params) {
+      switch (p.type) {
+        case ParamType.int:
+          args[p.key] = int.parse(_controllers[p.key]!.text.trim());
+          break;
+        case ParamType.double:
+          args[p.key] = double.parse(_controllers[p.key]!.text.trim());
+          break;
+        case ParamType.dateTime:
+          args[p.key] = DateTime.parse(_controllers[p.key]!.text.trim());
+          break;
+        case ParamType.stringList:
+          args[p.key] = _controllers[p.key]!
+              .text
+              .split(',')
+              .map((e) => e.trim())
+              .where((e) => e.isNotEmpty)
+              .toList();
+          break;
+        case ParamType.string:
+          args[p.key] = _controllers[p.key]!.text;
+          break;
+        case ParamType.bool:
+          args[p.key] = _boolValues[p.key];
+          break;
+        case ParamType.enumValue:
+          args[p.key] = _enumValues[p.key];
+          break;
+      }
+    }
+    return args;
+  }
+
+  Future<void> _run() async {
+    setState(() {
+      _loading = true;
+      _result = null;
+      _isError = false;
+    });
+    try {
+      final args = _collectArgs();
+      final response = await widget.call.run(widget.client, args);
+      setState(() => _result = formatResult(response));
+    } on Fault catch (fault) {
+      setState(() {
+        _isError = true;
+        _result = _formatFault(fault);
+      });
+    } catch (e, st) {
+      setState(() {
+        _isError = true;
+        _result = 'Error: $e\n\n$st';
+      });
+    } finally {
+      setState(() => _loading = false);
+    }
+  }
+
+  String _formatFault(Fault fault) {
+    final errors = (fault.errors ?? [])
+        .map((e) => '  - code: ${e.code}, field: ${e.field}, '
+            'resource: ${e.resource}')
+        .join('\n');
+    return 'Strava Fault\nmessage: ${fault.message}\nerrors:\n$errors';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final call = widget.call;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(call.name),
+        actions: [
+          if (call.isWrite)
+            const Padding(
+              padding: EdgeInsets.only(right: 12),
+              child: Chip(
+                label: Text('WRITE'),
+                backgroundColor: Color(0xFFFFE0B2),
+                visualDensity: VisualDensity.compact,
+              ),
+            ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(call.description,
+              style: Theme.of(context).textTheme.bodyMedium),
+          if (call.isWrite)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(
+                '⚠ This call mutates your Strava data.',
+                style: TextStyle(color: Colors.orange.shade800),
+              ),
+            ),
+          const SizedBox(height: 16),
+          ...call.params.map(_buildField),
+          const SizedBox(height: 16),
+          FilledButton.icon(
+            onPressed: _loading ? null : _run,
+            icon: _loading
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2))
+                : const Icon(Icons.play_arrow),
+            label: Text(_loading ? 'Running…' : 'Run'),
+          ),
+          const SizedBox(height: 16),
+          if (_result != null) _buildResult(context),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildField(ApiParam p) {
+    if (p.type == ParamType.bool) {
+      return SwitchListTile(
+        contentPadding: EdgeInsets.zero,
+        title: Text(p.label),
+        value: _boolValues[p.key]!,
+        onChanged: (v) => setState(() => _boolValues[p.key] = v),
+      );
+    }
+    if (p.type == ParamType.enumValue) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: InputDecorator(
+          decoration: InputDecoration(
+              labelText: p.label, border: const OutlineInputBorder()),
+          child: DropdownButtonHideUnderline(
+            child: DropdownButton<Object>(
+              isExpanded: true,
+              value: _enumValues[p.key],
+              items: p.enumValues!
+                  .map((v) => DropdownMenuItem<Object>(
+                        value: v,
+                        child: Text(p.enumLabel?.call(v) ?? v.toString()),
+                      ))
+                  .toList(),
+              onChanged: (v) => setState(() => _enumValues[p.key] = v!),
+            ),
+          ),
+        ),
+      );
+    }
+    final isNumber =
+        p.type == ParamType.int || p.type == ParamType.double;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: TextField(
+        controller: _controllers[p.key],
+        keyboardType: isNumber
+            ? const TextInputType.numberWithOptions(decimal: true, signed: true)
+            : TextInputType.text,
+        decoration: InputDecoration(
+          labelText: p.label,
+          helperText: p.hint,
+          helperMaxLines: 3,
+          border: const OutlineInputBorder(),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildResult(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Text(_isError ? 'Error' : 'Response',
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: _isError ? Colors.red : Colors.green.shade800)),
+            const Spacer(),
+            TextButton.icon(
+              icon: const Icon(Icons.copy, size: 16),
+              label: const Text('Copy'),
+              onPressed: () {
+                Clipboard.setData(ClipboardData(text: _result ?? ''));
+                ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Copied')));
+              },
+            ),
+          ],
+        ),
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: _isError ? const Color(0xFFFFEBEE) : const Color(0xFFF5F5F5),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: SelectableText(
+            _result ?? '',
+            style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/example/lib/secret.dart.example
+++ b/example/lib/secret.dart.example
@@ -1,0 +1,7 @@
+// Copy this file to `secret.dart` and fill in your Strava API application
+// credentials from https://www.strava.com/settings/api
+//
+// `secret.dart` is git-ignored so your credentials are never committed.
+
+const String clientId = "YOUR_CLIENT_ID";
+const String secret = "YOUR_CLIENT_SECRET";

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,21 +12,16 @@ description: Describes how to use strava_flutter package
 version: 1.0.1+5
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
 
-  # strava_flutter: ^1.0.6+17
-  # To test locally
-  intl: ^0.18.0
+  intl: ^0.20.2
 
   strava_client:
     path: ../
-
-dependency_overrides:
-  file: ^6.1.4
 
 dev_dependencies:
   test: any

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -1,30 +1,15 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility that Flutter provides. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
+// Smoke test: the explorer boots and shows the login affordance.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:example/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+  testWidgets('shows login button and empty-state on launch',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Login with Strava'), findsOneWidget);
+    expect(find.text('Login to run API calls.'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Replaces the placeholder example (dead API list, no `onTap`, stale SDK) with a working playground for exercising the `strava_client` package against the live Strava API.

## Features
- OAuth login / de-authorization; access token shown + copyable. Calls gated until authenticated.
- Grouped list of **all** repository calls: Athlete, Activity, Club, Gear, Route, Running races, Segment efforts, Segment, Stream (incl. the new `*ByType`), Upload.
- A form is generated per call from a declarative registry — handles int, double, string, bool, date, enum, and comma-separated key-list params.
- Runs the call and pretty-prints the JSON response, or shows the Strava `Fault`, with copy-to-clipboard.
- Write calls (`createActivity`, `updateActivity`, `starSegment`) are tagged **WRITE**.

## Structure
- `lib/api/api_models.dart` — `ApiParam` / `ApiCall` descriptors.
- `lib/api/api_registry.dart` — every call declared as data (group, params, `run` closure). Add a call here; the UI renders it automatically.
- `lib/api/result_format.dart` — generic model/list/binary → pretty JSON.
- `lib/screens/call_screen.dart` — dynamic form + runner + result view.
- `lib/main.dart` — login panel + grouped navigation.

## Housekeeping
- Example SDK bumped to `>=3.8.0 <4.0.0`; dropped the stale `file` dependency override; `intl` → `0.20.2`.
- `secret.dart.example` template added; `secret.dart` stays git-ignored.
- Widget smoke test updated; README rewritten.

## Verification
`flutter analyze` clean; widget test passes. Mobile (iOS/Android) is the supported target — the web build is blocked by a `dio` ↔ `dio_web_adapter` transitive version mismatch, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)