### PR TITLE
Automatic token refresh + gear id type fix (2.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [2.3.0]
+Backwards compatible (additions + deprecations only).
+
+### Added
+- Automatic access-token refresh: every authenticated request now transparently
+  refreshes an expired token via the stored refresh token before sending
+  (`SessionManager.getValidToken()`), with concurrent requests sharing a single
+  in-flight refresh. Previously an expired token caused requests to fail.
+- `RepositoryGear.getGearById(String gearId)` — gear ids are strings
+  (e.g. `b1234567`), which the old `int`-typed method could not represent.
+
+### Deprecated
+- `RepositoryGear.getGear(int gearId)` — use `getGearById(String)`.
+
 ## [2.2.0]
 Modernization pass — fully backwards compatible (additions + deprecations only).
 

--- a/example/lib/api/api_registry.dart
+++ b/example/lib/api/api_registry.dart
@@ -228,8 +228,13 @@ final List<ApiCall> kApiCalls = [
     group: "Gear",
     name: "getGear",
     description: "Gear (bike/shoe) by id.",
-    params: [_id("gearId", "Gear id")],
-    run: (c, a) => c.gears.getGear(a["gearId"] as int),
+    params: [
+      ApiParam(
+          key: "gearId",
+          label: "Gear id (e.g. b1234567)",
+          type: ParamType.string)
+    ],
+    run: (c, a) => c.gears.getGearById(a["gearId"] as String),
   ),
 
   // ------------------------------------------------------------------ Route

--- a/lib/src/common/session_manager.dart
+++ b/lib/src/common/session_manager.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:dio/dio.dart';
 import 'package:strava_client/src/common/local_storage.dart';
 import 'package:strava_client/src/domain/model/model_authentication_response.dart';
 import 'package:strava_client/src/domain/model/model_authentication_scopes.dart';
@@ -52,6 +53,43 @@ class SessionManager {
     DateTime expiresAt =
         DateTime.fromMillisecondsSinceEpoch(token.expiresAt * 1000);
     return DateTime.now().isAfter(expiresAt);
+  }
+
+  Future<TokenResponse?>? _refreshInFlight;
+
+  /// Returns a non-expired token, transparently refreshing it via the stored
+  /// refresh token when the current access token has expired.
+  ///
+  /// Concurrent callers share a single in-flight refresh. Returns `null` when
+  /// no token is stored (i.e. the user has not authenticated yet).
+  Future<TokenResponse?> getValidToken() async {
+    final token = await getToken();
+    if (token == null) return null;
+    if (!isTokenExpired(token)) return token;
+    return _refreshInFlight ??= _refreshToken(token)
+        .whenComplete(() => _refreshInFlight = null);
+  }
+
+  Future<TokenResponse> _refreshToken(TokenResponse token) async {
+    final response = await Dio().post(
+      "https://www.strava.com/api/v3/oauth/token",
+      queryParameters: {
+        "client_id": clientId,
+        "client_secret": secret,
+        "grant_type": "refresh_token",
+        "refresh_token": token.refreshToken,
+      },
+    );
+    final refreshed =
+        TokenResponse.fromJson(Map<String, dynamic>.from(response.data))
+          // The refresh response does not echo the granted scopes; carry the
+          // previously stored scope string forward.
+          ..scopes = token.scopes;
+    await setToken(
+      token: refreshed,
+      scopes: AuthenticationScopeHelper.generateScopes(token.scopes ?? ""),
+    );
+    return refreshed;
   }
 
   Future<void> logout() {

--- a/lib/src/data/repository/client.dart
+++ b/lib/src/data/repository/client.dart
@@ -11,7 +11,7 @@ class ApiClient {
   static Future<Dio> _getDioClient({bool isAuthenticated = true}) async {
     var dio = Dio();
     if (isAuthenticated) {
-      var token = await sl<SessionManager>().getToken();
+      var token = await sl<SessionManager>().getValidToken();
       var headers = Map<String, dynamic>();
       if (token != null) {
         headers.putIfAbsent(

--- a/lib/src/data/repository/repository_gear_impl.dart
+++ b/lib/src/data/repository/repository_gear_impl.dart
@@ -3,8 +3,12 @@ import 'package:strava_client/src/domain/model/model_gear.dart';
 import 'package:strava_client/src/domain/repository/repository_gear.dart';
 
 class RepositoryGearImpl extends RepositoryGear {
+  @Deprecated('Gear ids are strings; use getGearById(String).')
   @override
-  Future<Gear> getGear(int gearId) {
+  Future<Gear> getGear(int gearId) => getGearById(gearId.toString());
+
+  @override
+  Future<Gear> getGearById(String gearId) {
     return ApiClient.getRequest(
         endPoint: "/v3/gear/$gearId",
         dataConstructor: (data) =>

--- a/lib/src/domain/repository/repository_gear.dart
+++ b/lib/src/domain/repository/repository_gear.dart
@@ -5,5 +5,12 @@ abstract class RepositoryGear {
   /// Returns a [Gear] from its [gearId].
   ///
   /// {@macro fault_management}
+  @Deprecated('Gear ids are strings (e.g. "b1234567"), not ints. '
+      'Use getGearById(String) instead. Removed in the next major version.')
   Future<Gear> getGear(int gearId);
+
+  /// Returns a [Gear] from its string [gearId] (e.g. `"b1234567"`).
+  ///
+  /// {@macro fault_management}
+  Future<Gear> getGearById(String gearId);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: strava_client
 description: A Flutter Client for Strava V3 Api Based on the old strava_flutter api.
-version: 2.2.0
+version: 2.3.0
 homepage: https://github.com/dreampowder/strava_flutter
 
 environment:


### PR DESCRIPTION
Two backwards-compatible fixes (additions + deprecations only).

## 1. Automatic token refresh
Previously the access token was attached to each request once and never refreshed — an expired token simply caused requests to fail. Now:
- `SessionManager.getValidToken()` returns a non-expired token, transparently refreshing via the stored refresh token when the current one has expired. Concurrent callers share a single in-flight refresh (no refresh stampede).
- `ApiClient` uses `getValidToken()` for every authenticated request.

The refresh hits `POST /oauth/token` (grant_type=refresh_token) with a bare Dio client (no auth header needed), persists the new token via `setToken`, and carries the previously granted scope string forward (the refresh response doesn't echo scopes).

## 2. Gear id type fix
Strava gear ids are strings (e.g. `b1234567`), but `RepositoryGear.getGear` took an `int` — so the call could never work for real gear.
- Added `getGearById(String gearId)`.
- Deprecated `getGear(int)` (now delegates to `getGearById(id.toString())`).
- Updated the example explorer to use `getGearById` with a string field.

## Verification
`dart analyze lib test` clean; `flutter test` green (19); example analyzes clean. Version bumped to **2.3.0** with CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)